### PR TITLE
Add support for older GHC versions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -58,6 +58,16 @@ jobs:
             compilerVersion: 8.8.4
             setup-method: hvr-ppa
             allow-failure: false
+          - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
+            allow-failure: false
+          - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/atomic-modify-general.cabal
+++ b/atomic-modify-general.cabal
@@ -32,7 +32,9 @@ category:           Concurrency
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 -- extra-source-files:
-tested-with: GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.7, GHC == 9.4.4, GHC == 9.6.1
+tested-with:
+     GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7
+   , GHC == 9.0.2, GHC == 9.2.7, GHC == 9.4.4, GHC == 9.6.1
 source-repository head
     type:     git
     location: http://github.com/treeowl/atomic-modify-general.git
@@ -48,14 +50,20 @@ library
     other-modules:
         Data.IORef.AtomicModify.SmallArraySize
     -- other-extensions:
-    build-depends:    base >= 4.13.0 && < 4.19
+    build-depends:    base >= 4.11 && < 4.19
                     , primitive
     hs-source-dirs:   src
     if impl (ghc >= 8.10)
       hs-source-dirs: compat-sa-size-recent
     else
       hs-source-dirs: compat-sa-size-old
+    if impl (ghc < 8.8)
+      hs-source-dirs: compat-atomic-modify-old
+      other-modules:
+        Data.IORef.AtomicModify.Generic.UnsafeToPair
     default-language: Haskell2010
+    if impl (ghc < 8.6)
+      ghc-options: -Wno-unticked-promoted-constructors
 
 test-suite atomic-modify-general-test
     import:           warnings
@@ -66,5 +74,5 @@ test-suite atomic-modify-general-test
     hs-source-dirs:   test
     main-is:          Main.hs
     build-depends:
-         base >= 4.13.0 && < 4.19
+         base >= 4.11.0 && < 4.19
        , atomic-modify-general

--- a/compat-atomic-modify-old/Data/IORef/AtomicModify/Generic/UnsafeToPair.hs
+++ b/compat-atomic-modify-old/Data/IORef/AtomicModify/Generic/UnsafeToPair.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE Unsafe #-}
+
+{-# OPTIONS_GHC -fno-worker-wrapper #-}
+
+
+-- | The documentation for `unsafeCoerce` firmly warns that it should not be
+-- used to coerce between actually different types. But we want to produce
+-- selector thunks and we don't want to rely on Generic nonsense inlining away
+-- to do so. So ... we use `unsafeCoerce` in an entirely illegitimate way. We
+-- use this module to make sure our bogus coercions don't escape and cause
+-- trouble in the optimizer. Using `-fno-worker-wrapper` and `NOINLINE` pragmas
+-- prevents GHC from producing unfoldings for these hideous functions, so
+-- they're quite opaque. However, it still produces demand signatures and arity
+-- info, which *tend* to be good to have right. I'm not sure how much they
+-- matter in this particular case.
+module Data.IORef.AtomicModify.Generic.UnsafeToPair
+  ( unsafeToPair
+  , unsafeFromPair
+  ) where
+
+import GHC.Exts (Any)
+import Unsafe.Coerce (unsafeCoerce)
+
+-- | Pretend that an arbitrary type is actually a pair whose first
+-- component is whatever we want it to be. This is very unsafe!
+unsafeToPair :: t -> (a, Any)
+unsafeToPair = unsafeCoerce
+{-# NOINLINE unsafeToPair #-}
+
+-- | Coerce (back) from a (fake) pair to the actual type.
+unsafeFromPair :: (a, Any) -> t
+unsafeFromPair = unsafeCoerce
+{-# NOINLINE unsafeFromPair #-}

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,14 @@
+{-# language DeriveGeneric #-}
 module Main (main) where
+import Data.IORef
+import Data.IORef.AtomicModify.Generic
+import Control.Monad
+import GHC.Generics
+
+data Pair a b = Pair a b
+  deriving (Show, Generic)
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented."
+main = do
+  ref <- newIORef (1 :: Int)
+  replicateM_ 5 $ atomicModifyIORef2Native ref (\i -> Pair (i + 1) i) >>= print


### PR DESCRIPTION
Add support for GHC 8.4 and 8.6. It's not so easy for me to play with even earlier ones locally, but I'm guessing not too many people are still using anything before 8.6 anyway.

Closes #2